### PR TITLE
chore: Netlify -> Vercel, RoostingGeese -> HonkingGoose

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 
 <!-- Mark the checkbox [X] if you agree with the item. -->
 
-- [ ] I provide my work under the [project license](https://github.com/RoostingGeese/git-gosling/blob/main/LICENSE.md).
+- [ ] I provide my work under the [project license](https://github.com/HonkingGoose/git-gosling/blob/main/LICENSE.md).
 
 ## Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@ Thanks for taking the time to contribute! :+1:
 
 ## Licensing your work to us
 
-By opening a pull request, you agree to provide your work under the [project license](https://github.com/RoostingGeese/git-gosling/blob/main/LICENSE.md).
+By opening a pull request, you agree to provide your work under the [project license](https://github.com/HonkingGoose/git-gosling/blob/main/LICENSE.md).
 
 ## Community and behavioral expectations
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-![Docusaurus build](https://github.com/RoostingGeese/git-gosling/workflows/Docusaurus%20build/badge.svg)
-![Prettier](https://github.com/RoostingGeese/git-gosling/workflows/Prettier/badge.svg)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/b5c74514-690d-49c9-8f0c-ed7317f02cf9/deploy-status)](https://app.netlify.com/sites/git-gosling/deploys)
+![Docusaurus build](https://github.com/HonkingGoose/git-gosling/workflows/Docusaurus%20build/badge.svg)
+![Prettier](https://github.com/HonkingGoose/git-gosling/workflows/Prettier/badge.svg)
 
 # Grow from gosling to goose with Git
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,13 +1,13 @@
 module.exports = {
   title: "Git Gosling",
   tagline: "Grow from gosling to goose with this Git guide.",
-  url: "https://git-gosling.netlify.app/",
+  url: "https://git-gosling.vercel.app/",
   baseUrl: "/",
   onBrokenLinks: "throw",
   onDuplicateRoutes: "throw",
   onBrokenMarkdownLinks: "throw",
   favicon: "img/favicon.ico",
-  organizationName: "RoostingGeese", // Usually your GitHub org/user name.
+  organizationName: "HonkingGoose", // Usually your GitHub org/user name.
   projectName: "git-gosling", // Usually your repo name.
   themeConfig: {
     announcementBar: {
@@ -35,7 +35,7 @@ module.exports = {
           position: "left",
         },
         {
-          href: "https://github.com/RoostingGeese/git-gosling",
+          href: "https://github.com/HonkingGoose/git-gosling",
           label: "Git Gosling project on GitHub",
           position: "right",
         },
@@ -78,7 +78,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
-          editUrl: "https://github.com/RoostingGeese/git-gosling/edit/main/",
+          editUrl: "https://github.com/HonkingGoose/git-gosling/edit/main/",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
<!-- Thank you for helping! -->
<!-- This pull request template is adapted from ProGit 2's pull request template. -->

<!-- Mark the checkbox [X] if you agree with the item. -->

- [x] I provide my work under the [project license](https://github.com/RoostingGeese/git-gosling/blob/main/LICENSE.md).

## Changes

<!-- List your changes. -->

- Migrate to own namespace (`RoostingGeese` -> `HonkingGoose`
- Migrate from Netlify to Vercel
- Remove Netlify badge from README

## Context

<!--
Provide the necessary context to understand the changes you made.
If you are fixing an issue with this pull-request, use the "Fixes" keyword, like this:

Fixes #123
-->

Vercel has a more generous limit for bandwidth and build minutes than Netlify under their free tier.
I also like to have this project as a "showcase" project under my own namespace for now.