### PR TITLE
chore: pin GitHub Action digests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base"],
+  "extends": ["config:base", "helpers:pinGitHubActionDigests"],
   "dependencyDashboard": true,
   "prCreation": "not-pending",
   "internalChecksFilter": "strict",


### PR DESCRIPTION
<!-- Thank you for helping! -->
<!-- This pull request template is adapted from ProGit 2's pull request template. -->

<!-- Mark the checkbox [X] if you agree with the item. -->

- [ ] I provide my work under the [project license](https://github.com/HonkingGoose/git-gosling/blob/main/LICENSE.md).

## Changes

<!-- List your changes. -->

- Pin our GitHub actions to a full length commit SHA

## Context

<!--
Provide the necessary context to understand the changes you made.
If you are fixing an issue with this pull-request, use the "Fixes" keyword, like this:

Fixes #123
-->

Renovate now supports pinning GitHub Actions to a full length commit SHA.
This helps ensure that the action that's reviewed in the PR is the one that's actually running.