### PR TITLE
chore: set better font weight for navbar title

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -23,3 +23,9 @@
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
+
+/* Set a better font-weight for the navbar title. */
+
+.navbar__title {
+  font-weight: 700;
+}


### PR DESCRIPTION
<!-- Thank you for helping! -->
<!-- This pull request template is adapted from ProGit 2's pull request template. -->

<!-- Mark the checkbox [X] if you agree with the item. -->

- [x] I provide my work under the [project license](https://github.com/HonkingGoose/git-gosling/blob/main/LICENSE.md).

## Changes

<!-- List your changes. -->

- Use a bold font instead of black for navbar title

## Context

<!--
Provide the necessary context to understand the changes you made.
If you are fixing an issue with this pull-request, use the "Fixes" keyword, like this:

Fixes #123
-->

Somehow Docusaurus has a regression where it uses `900` as the font-weight by default. This looks ugly with the font stack that comes with Docusaurus, so I'm overriding it with some custom CSS.