### PR TITLE
chore: remove dependencyDashboard true line

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "extends": ["config:base", "helpers:pinGitHubActionDigests"],
-  "dependencyDashboard": true,
   "prCreation": "not-pending",
   "internalChecksFilter": "strict",
   "lockFileMaintenance": {


### PR DESCRIPTION
<!-- Thank you for helping! -->
<!-- This pull request template is adapted from ProGit 2's pull request template. -->

<!-- Mark the checkbox [X] if you agree with the item. -->

- [x] I provide my work under the [project license](https://github.com/HonkingGoose/git-gosling/blob/main/LICENSE.md).

## Changes

<!-- List your changes. -->

- Remove `dependencyDashboard` = `true` line from Renovate config file

## Context

Renovate v26 now enables the dashboard by default.
We no longer need to tell Renovate to give us a dashboard manually.
