### PR TITLE
chore: add Gitpod badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![Docusaurus build](https://github.com/HonkingGoose/git-gosling/workflows/Docusaurus%20build/badge.svg)
 ![Prettier](https://github.com/HonkingGoose/git-gosling/workflows/Prettier/badge.svg)
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 # Git Gosling
 
 > Grow from gosling to goose with Git


### PR DESCRIPTION
- [x] I provide my work under the [project license](https://github.com/HonkingGoose/git-gosling/blob/main/LICENSE.md).

## Changes

- Add open in Gitpod badge to `readme.md`

## Context

This should make it easier for new contributors to get started.