### PR TITLE
chore: pin dependencies when installing with npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact = true


### PR DESCRIPTION
<!-- Thank you for helping! -->
<!-- This pull request template is adapted from ProGit 2's pull request template. -->

<!-- Mark the checkbox [X] if you agree with the item. -->

- [x] I provide my work under the [project license](https://github.com/HonkingGoose/git-gosling/blob/main/LICENSE.md).

## Changes

<!-- List your changes. -->

- Use `.npmrc` file with `save-exact = true`

## Context

<!--
Provide the necessary context to understand the changes you made.
If you are fixing an issue with this pull-request, use the "Fixes" keyword, like this:

Fixes #123
-->

Enforce pinned dependencies when installing things with `npm install`.