### PR TITLE
chore: drop engines field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "git-gosling",
   "version": "0.0.0",
   "private": true,
-  "engines": {
-    "node": "16.16.0",
-    "npm": "8.13.2"
-  },
   "scripts": {
     "prettier": "prettier --cache --check .",
     "prettier-fix": "prettier --cache --write .",


### PR DESCRIPTION
<!-- Thank you for helping! -->
<!-- This pull request template is adapted from ProGit 2's pull request template. -->

<!-- Mark the checkbox [X] if you agree with the item. -->

- [x] I provide my work under the [project license](https://github.com/HonkingGoose/git-gosling/blob/main/LICENSE.md).

## Changes

<!-- List your changes. -->

- Drop `engines` field from `package.json`

## Context

Renovate opens PRs to bump the versions in the `engines` field. This causes notification noise.

I don't want to publish to `npm`, so I can drop the field.