### PR TITLE
chore: enable Material for MkDocs features

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,10 @@ theme:
     repo: fontawesome/brands/github
 
   features:
+    - navigation.top
     - navigation.instant
+    - toc.integrate
+    - toc.follow
 
   palette:
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
- [x] I provide my work under the [project license](https://github.com/HonkingGoose/git-gosling/blob/main/LICENSE.md).

## Changes

- Enable some Material for MkDocs features:
  - `navigation.top`: back to top button
  - `toc.integrate`: Integrate table of content (sidebar is now on the left only)
  - `toc.follow` the anchor text in the sidebar now scrolls when you scroll the content

## Context

Drive-by PR, not fixing any issue with this.