### PR TITLE
chore: enable navigation pruning

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ theme:
     - toc.follow
     - content.action.edit
     - navigation.footer
+    - navigation.prune
 
   palette:
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
<!-- Thank you for helping! -->
<!-- This pull request template is adapted from ProGit 2's pull request template. -->

<!-- Mark the checkbox [X] if you agree with the item. -->

- [x] I provide my work under the [project license](https://github.com/HonkingGoose/git-gosling/blob/main/LICENSE.md).

## Changes

<!-- List your changes. -->

- Enable navigation pruning [^1]

## Context

Quote from the Material for MkDocs manual:

> When pruning is enabled, only the visible navigation items are included in the rendered HTML, **reducing the size of the built site by 33% or more**.

[^1]: [Material for MkDocs, navigation pruning](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-pruning)