### PR TITLE
chore: remove deprecated vercel silent option

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "github": {
-    "silent": true
-  }
-}


### PR DESCRIPTION
<!-- Thank you for helping! -->
<!-- This pull request template is adapted from ProGit 2's pull request template. -->

<!-- Mark the checkbox [X] if you agree with the item. -->

- [x] I provide my work under the [project license](https://github.com/HonkingGoose/git-gosling/blob/main/LICENSE.md).

## Changes

<!-- List your changes. -->

- Vercel deprecated the `github.silent` option so I'm removing it

## Context

Read [Vercel docs, silence GitHub comments](https://vercel.com/docs/deployments/git/vercel-for-github#silence-github-comments) to learn how to silence the Vercel bot comments.

<!--
Provide the necessary context to understand the changes you made.
If you are fixing an issue with this pull-request, use the "Fixes" keyword, like this:

Fixes #123
-->
