### PR TITLE
chore: validate anchors, drop `mkdocs`  as direct dependency

### DIFF
--- a/docs/getting_started/configuring_git.md
+++ b/docs/getting_started/configuring_git.md
@@ -63,7 +63,7 @@ You can tell Git what text editor you want to use.
 If you want to follow along with the Git sandbox I recommend that you install and use the `nano` editor.
 You can use another text editor if you want, but you might run into problems when you want to save your commit message.
 
-If you want to use another text editor, look at the table in the [Advanced Git configuration, code editor setup](../advanced_topics/advanced_git_configuration.md#Code-editor-setup) part of this guide.
+If you want to use another text editor, look at the table in the [Advanced Git configuration, code editor setup](../advanced_topics/advanced_git_configuration.md#code-editor-setup) part of this guide.
 
 ### Installing the nano text editor
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ validation:
   omitted_files: warn
   absolute_links: warn
   unrecognized_links: warn
+  anchors: warn
 
 repo_name: HonkingGoose/git-gosling
 repo_url: https://github.com/HonkingGoose/git-gosling

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 mkdocs-material==9.5.20
-mkdocs==1.6.0


### PR DESCRIPTION
<!-- Thank you for helping! -->
<!-- This pull request template is adapted from ProGit 2's pull request template. -->

<!-- Mark the checkbox [X] if you agree with the item. -->

- [x] I provide my work under the [project license](https://github.com/HonkingGoose/git-gosling/blob/main/LICENSE.md).

## Changes

<!-- List your changes. -->

- Validate anchors with the new for `mkdocs 1.6.0` config option: `anchors: warn`
- Fix broken anchor
- Drop `mkdocs` as direct dependency, so `mkdocs-material` can manage the `mkdocs` dependency

## Context

Fix some docs stuff, and follow the "how to install `mkdocs-material`" guidance from the `mkdocs-material` maintainers.